### PR TITLE
Change build platform to Any CPU

### DIFF
--- a/Source/CalcEngine/CalcEngine.sln
+++ b/Source/CalcEngine/CalcEngine.sln
@@ -15,7 +15,8 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{EE53DAD4-D6C8-4C47-9AD4-5B3BA2900DC2}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{EE53DAD4-D6C8-4C47-9AD4-5B3BA2900DC2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE53DAD4-D6C8-4C47-9AD4-5B3BA2900DC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EE53DAD4-D6C8-4C47-9AD4-5B3BA2900DC2}.Debug|x86.ActiveCfg = Debug|x86
 		{EE53DAD4-D6C8-4C47-9AD4-5B3BA2900DC2}.Debug|x86.Build.0 = Debug|x86
 		{EE53DAD4-D6C8-4C47-9AD4-5B3BA2900DC2}.Release|Any CPU.ActiveCfg = Release|x86

--- a/Source/CalcEngine/CalcEngine/CalcEngine.csproj
+++ b/Source/CalcEngine/CalcEngine/CalcEngine.csproj
@@ -50,6 +50,26 @@
     <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Currently the build config will build CalcEngine explicitly for x86 and the tests for Any CPU. This causes issues if you're running a 64 bit process against this 32 bit calcengine dll in the form of BadImageExceptions at runtime.

This also fixes a warning: `warning MSB3270: There was a mismatch between the processor architecture of the project being built "MSIL" and the processor architecture of the reference...` telling you this might happen.

Build config also now builds CalcEngine as well as CalcEngine.Tests since it was odd to only build tests by default.