### PR TITLE
Changed Round to use MidpointRounding AwayFromZero

### DIFF
--- a/Source/CalcEngine.Tests/ComplexExcelFunctionTests.cs
+++ b/Source/CalcEngine.Tests/ComplexExcelFunctionTests.cs
@@ -42,6 +42,7 @@ namespace CalcEngine.Tests
             Eval("=ROUND(1.20,2)", 1.2d);
             Eval("=ROUND(1.20)", 1d);
             Eval("=ROUND(1.50)", 2d);
+            Eval("=ROUND(2.50)", 3d);
             Assert.Throws<Exception>(() => Eval("=ROUND()", 0d));
         }
 

--- a/Source/CalcEngine/CalcEngine/Functions/MathTrig.cs
+++ b/Source/CalcEngine/CalcEngine/Functions/MathTrig.cs
@@ -229,7 +229,7 @@ namespace CalcEngine
             {
                 toDecimals = (int)p[p.Count - 1];
             }
-            return Math.Round(p[0], toDecimals);
+            return Math.Round(p[0], toDecimals, MidpointRounding.AwayFromZero);
         }
         static object Sign(List<Expression> p)
         {


### PR DESCRIPTION
Changed the Round function to use the optional MidpointRounding parameter so that it will round away from zero instead of using bankers rounding. This should more closely mimic Excel's functionality:

=ROUND(2.5) is 3
=ROUND(1.5) is 2

Before it would be:
=ROUND(2.5) is 2
=ROUND(1.5) is 2

Added here if you'd like to merge this upstream.